### PR TITLE
Change ln -s to mv

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox) plugin that attempts
 
    mkdir -p ~/.local/share/rhythmbox/plugins
 
-   ln -s rhythmbox-podqueuer/plugin ~/.local/share/rhythmbox/plugins/podqueuer
+   mv rhythmbox-podqueuer/plugin ~/.local/share/rhythmbox/plugins/podqueuer
    ```
 2. Run Rhythmbox
 3. Tools &rarr; Plugins

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox) plugin that attempts
 
    mkdir -p ~/.local/share/rhythmbox/plugins
 
-   ln -s {PATH_TO_HERE}/rhythmbox-podqueuer/plugin ~/.local/share/rhythmbox/plugins/podqueuer
+   ln -s $(pwd)/rhythmbox-podqueuer/plugin ~/.local/share/rhythmbox/plugins/podqueuer
    ```
 2. Run Rhythmbox
 3. Tools &rarr; Plugins

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A simple [Rhythmbox](https://wiki.gnome.org/Apps/Rhythmbox) plugin that attempts
 
    mkdir -p ~/.local/share/rhythmbox/plugins
 
-   mv rhythmbox-podqueuer/plugin ~/.local/share/rhythmbox/plugins/podqueuer
+   ln -s {PATH_TO_HERE}/rhythmbox-podqueuer/plugin ~/.local/share/rhythmbox/plugins/podqueuer
    ```
 2. Run Rhythmbox
 3. Tools &rarr; Plugins


### PR DESCRIPTION
I don't particularly know why, but symbolic link doesn't work for rhythmbox plugins anymore, you have to actually move the folder there.